### PR TITLE
Add makefile and docker image for services being built with this image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,9 @@ RUN mkdir golangci && cd golangci && git clone https://github.com/golangci/golan
     cd golangci-lint && git reset --hard $(git rev-list --tags --max-count=1) && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint && \
     cd ../../ && rm -rf golangci
+
+# Copy in makefile and project docker image
+WORKDIR /build
+ADD ./Makefile .
+ADD ./Dockerfile.project .
+RUN mkdir project images

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ RUN mkdir golangci && cd golangci && git clone https://github.com/golangci/golan
 WORKDIR /build
 ADD ./Makefile .
 ADD ./Dockerfile.project .
-RUN mkdir project images
+RUN mkdir project

--- a/Dockerfile.project
+++ b/Dockerfile.project
@@ -1,0 +1,11 @@
+FROM alpine:3.9
+
+ARG EXECUTABLE
+
+ENV APP=${EXECUTABLE}
+
+RUN apk add --no-cache ca-certificates
+ADD ./bin/${EXECUTABLE} /bin/${EXECUTABLE}
+ADD ./project/static /
+
+ENTRYPOINT exec ${APP}

--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,33 @@ ifneq ("$(wildcard project/app.mk)","")
 	include project/app.mk
 endif
 
-
 # --------------------------------------------------------------------------------------------------
 # Variables
 # --------------------------------------------------------------------------------------------------
 
 ifndef APP_NAME
-$(error APP_NAME is not set, create a .mk file and set it)
+$(error APP_NAME is not set in the app.mk file)
 endif
 
 ifndef APP_DESCRIPTION
-$(error APP_DESCRIPTION is not set, create a .mk file and set it)
+$(error APP_DESCRIPTION is not set in the app.mk file)
 endif
+
 
 GIT_SUMMARY := $(shell cd project && git describe --tags --dirty --always)
 GIT_BRANCH := $(shell cd project && git rev-parse --abbrev-ref HEAD)
 BUILD_STAMP := $(shell date -u '+%Y-%m-%dT%H:%M:%S%z')
+
+DOCKER_REGISTRY ?= registry.uw.systems
+DOCKER_NAMESPACE ?= partner
+MAIN_IMAGE_NAME := $(subst $(DOCKER_NAMESPACE)-,,$(APP_NAME))
+DOCKER_BASE_NAME ?= $(DOCKER_REGISTRY)/$(DOCKER_NAMESPACE)
+
+ifeq ($(GIT_BRANCH), master)
+    DOCKER_TAG := latest
+else
+    DOCKER_TAG := $(GIT_BRANCH)
+endif
 
 LDFLAGS := -ldflags '-s \
 	-X "github.com/utilitywarehouse/partner-pkg/meta.ApplicationName=$(APP_NAME)" \
@@ -50,7 +61,7 @@ lint-ci: ## run the linter
 
 build-app-ci:
 ifneq ("$(wildcard project/main.go)","")
-	cd project && CGO_ENABLED=0 go build $(LDFLAGS) -o bin/$(APP_NAME) -a .
+	cd project && CGO_ENABLED=0 go build $(LDFLAGS) -o ../bin/$(MAIN_IMAGE_NAME) -a .
 endif
 
 cmd_sources = $(dir $(wildcard ./project/cmd/*/main.go))
@@ -65,11 +76,48 @@ endef
 
 build-commands-ci: $(cmds) ## build all commands
 
-build-all-ci: build-app-ci build-commands-ci
+build-all: build-app-ci build-commands-ci
 
 # --------------------------------------------------------------------------------------------------
-# Fallback
+# Docker Tasks
 # --------------------------------------------------------------------------------------------------
 
-%: ## fallback to the project makefile
-	cd project && $(MAKE) -f Makefile $@
+docker_commands = $(foreach source,$(cmd_sources),$(subst /,,$(subst ./project/cmd/,docker-build-cmd-,$(source))))
+
+define docker-build
+	docker build -f Dockerfile.project -t $(DOCKER_BASE_NAME)/$(image_name):$(CIRCLE_SHA1) . --build-arg EXECUTABLE=$(<F)
+	docker save --output ./images/$(image_name).tar $(DOCKER_BASE_NAME)/$(image_name):$(CIRCLE_SHA1)
+endef
+
+docker-build-app: ## build docker image for main app
+	docker build -f Dockerfile.project -t $(DOCKER_BASE_NAME)/$(MAIN_IMAGE_NAME):$(CIRCLE_SHA1) . --build-arg EXECUTABLE=$(MAIN_IMAGE_NAME)
+	docker save --output ./images/$(MAIN_IMAGE_NAME).tar $(DOCKER_BASE_NAME)/$(MAIN_IMAGE_NAME):$(CIRCLE_SHA1)
+
+docker-build-cmd-%: image_name = $(MAIN_IMAGE_NAME)-$(subst docker-build-cmd-,,$@)
+docker-build-cmd-%: ## build docker image for one command
+	$(docker-build)
+
+docker-build-commands: $(docker_commands)
+
+ensure-static: ## ensures that a static folder exists in the project
+	mkdir -p project/static
+
+docker-build-all: ensure-static build-all docker-build-app docker-build-commands
+
+image_sources = $(sort $(shell find ./images -mindepth 1 -maxdepth 1 -exec basename {} \;))
+images = $(foreach image,$(image_sources),docker-push-image-$(subst .tar,,$(image)))
+
+define docker-push-image
+	docker load --input ./images/$(image_name).tar
+	docker tag $(DOCKER_BASE_NAME)/$(image_name):$(CIRCLE_SHA1) $(DOCKER_BASE_NAME)/$(image_name):$(DOCKER_TAG)
+	docker push $(DOCKER_BASE_NAME)/$(image_name)
+endef
+
+docker-push-image-%: image_name = $(subst docker-push-image-,,$@)
+docker-push-image-%: ## load tag and push a single docker image
+	$(docker-push-image)
+
+docker-login:
+	@docker login -u $(DOCKER_ID) -p $(DOCKER_PASSWORD) $(DOCKER_REGISTRY)
+
+docker-push-all: docker-login $(images)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+
+ifeq ("$(wildcard project)","")
+$(error project directory doesn't exist)
+endif
+
+ifneq ("$(wildcard project/app.mk)","")
+	include project/app.mk
+endif
+
+
+# --------------------------------------------------------------------------------------------------
+# Variables
+# --------------------------------------------------------------------------------------------------
+
+ifndef APP_NAME
+$(error APP_NAME is not set, create a .mk file and set it)
+endif
+
+ifndef APP_DESCRIPTION
+$(error APP_DESCRIPTION is not set, create a .mk file and set it)
+endif
+
+GIT_SUMMARY := $(shell cd project && git describe --tags --dirty --always)
+GIT_BRANCH := $(shell cd project && git rev-parse --abbrev-ref HEAD)
+BUILD_STAMP := $(shell date -u '+%Y-%m-%dT%H:%M:%S%z')
+
+LDFLAGS := -ldflags '-s \
+	-X "github.com/utilitywarehouse/partner-pkg/meta.ApplicationName=$(APP_NAME)" \
+	-X "github.com/utilitywarehouse/partner-pkg/meta.ApplicationDescription=$(APP_DESCRIPTION)" \
+	-X "github.com/utilitywarehouse/partner-pkg/meta.GitSummary=$(GIT_SUMMARY)" \
+	-X "github.com/utilitywarehouse/partner-pkg/meta.GitBranch=$(GIT_BRANCH)" \
+	-X "github.com/utilitywarehouse/partner-pkg/meta.BuildStamp=$(BUILD_STAMP)"'
+
+# --------------------------------------------------------------------------------------------------
+# Setup Tasks
+# --------------------------------------------------------------------------------------------------
+
+install-ci: ## install dependencies and redact github token
+	cd project && go get -d -v ./... 2>&1 | sed -e "s/[[:alnum:]]*:x-oauth-basic/redacted/"
+
+test-ci: ## run tests on package and all subpackages
+	cd project && go test $(LDFLAGS) -v -race -tags integration ./...
+
+lint-ci: ## run the linter
+	cd project && golangci-lint run --deadline=2m
+
+# --------------------------------------------------------------------------------------------------
+# Build Tasks
+# --------------------------------------------------------------------------------------------------
+
+build-app-ci:
+ifneq ("$(wildcard project/main.go)","")
+	cd project && CGO_ENABLED=0 go build $(LDFLAGS) -o bin/$(APP_NAME) -a .
+endif
+
+cmd_sources = $(dir $(wildcard ./project/cmd/*/main.go))
+cmds = $(foreach source,$(cmd_sources),$(patsubst %/,%,$(subst ./project/cmd,./bin,$(source))))
+
+define go-build
+	cd ./$< && CGO_ENABLED=0 go build $(LDFLAGS) -o ./../../../$@ -a .
+endef
+
+./bin/%: ./project/cmd/% ## build individual command
+	$(go-build)
+
+build-commands-ci: $(cmds) ## build all commands
+
+build-all-ci: build-app-ci build-commands-ci
+
+# --------------------------------------------------------------------------------------------------
+# Fallback
+# --------------------------------------------------------------------------------------------------
+
+%: ## fallback to the project makefile
+	cd project && $(MAKE) -f Makefile $@


### PR DESCRIPTION
This will build the `main.go` file that you have in the root of your project and put it in a docker image called `registry.uw.systems/partner/$(APP_NAME)` app name is taken from `app.mk` file located in the root of your repo. If the app name starts with `partner-` it will trim that. It will also build separate images for every command located in the `cmd` directory. These will be called `registry.uw.systems/partner/$(APP_NAME)-$(CMD_NAME)`, where `CMD_NAME` is the name of your command. Finally it will also copy `static` directory from the root of your repo to every image. It uses it's own Dockerfile, so we can remove them from each repository and update all at once, so we can switch to a newer version of the alpine or some other image whenever we want for each repo. This also simplifies circle config and allows us to remove some targets from the project makefile. For a complete example of a migration to this approach see https://github.com/utilitywarehouse/partner-contact-api/pull/45