### PR TITLE
Bump go version to 1.12.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM circleci/golang:1.11
+FROM circleci/golang:1.12
 
 USER root
 WORKDIR /go/src/github.com/
 
-ENV PROTOBUF_VERSION="3.6.1"
+ENV PROTOBUF_VERSION="3.7.0"
 
 # Dowload given version of the protobuf binary
 RUN wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip && \
@@ -42,4 +42,4 @@ RUN mkdir golangci && cd golangci && git clone https://github.com/golangci/golan
 WORKDIR /build
 ADD ./Makefile .
 ADD ./Dockerfile.project .
-RUN mkdir project
+RUN mkdir project && mkdir bin


### PR DESCRIPTION
I've tagged master as version 1.11.5 if anything needs to use that version.